### PR TITLE
Feat/chat

### DIFF
--- a/src/main/java/sesac_3rd/sesac_3rd/config/security/WebSecurityConfig.java
+++ b/src/main/java/sesac_3rd/sesac_3rd/config/security/WebSecurityConfig.java
@@ -34,7 +34,16 @@ public class WebSecurityConfig {
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 // JWT 를 사용하고 있으므로 세션 관리하지 않음
                 .authorizeHttpRequests(authorize -> authorize
-                        .requestMatchers("/", "/auth/**", "/api/user/**","/api/place/**", "/api/meeting/**", "/api/review/**")
+                        .requestMatchers("/",
+                                "/auth/**",
+                                "/api/user/**",
+                                "/api/place/**",
+                                "/api/meeting/**",
+                                "/api/review/**",
+                                "/api/chatroom/**",
+                                "/api/chatmsg/**",
+                                "/api/report"
+                        )
                         .permitAll()
                         .anyRequest().authenticated());
         // 요청의 인증을 "/", "/auth/**"경로는 인증없이 접근 가능 (그 외 모든 경로는 인증 필요)

--- a/src/main/java/sesac_3rd/sesac_3rd/controller/ChatController.java
+++ b/src/main/java/sesac_3rd/sesac_3rd/controller/ChatController.java
@@ -62,4 +62,20 @@ public class ChatController {
 
     }
 
+
+
+    // 메세지 내역 조회 (페이지네이션 적용 - 채팅생성시간 오름차순 적용)
+    @GetMapping("/chatmsg/{chatroomId}")
+    // /api/chatroom/chatmsg/{chatroomId}?page={page}&size={size}
+    public ResponseEntity<ResponseHandler<PaginationResponseDTO<ChatMessageDTO.ChatMessageList>>> getChatMessages(@PathVariable("chatroomId") Long chatroomId,
+                                                                                                                  @RequestParam int page,
+                                                                                                                  @RequestParam int size) {
+
+        PaginationResponseDTO<ChatMessageDTO.ChatMessageList> chatMessages = chatMessageService.getChatMessages(chatroomId, page, size);
+
+        return ResponseHandler.response(chatMessages, HttpStatus.OK, "채팅 메시지 리스트 조회 성공");
+    }
+
+
+
 }

--- a/src/main/java/sesac_3rd/sesac_3rd/controller/ChatController.java
+++ b/src/main/java/sesac_3rd/sesac_3rd/controller/ChatController.java
@@ -23,7 +23,7 @@ import sesac_3rd.sesac_3rd.service.chat.ChatRoomService;
 @RequestMapping("/api/chatroom")
 @RequiredArgsConstructor
 public class ChatController {
-    private final ChatRoomService chatService;
+    private final ChatRoomService chatRoomService;
     private final ChatMessageService chatMessageService;
     private final ChatRoomMapper chatRoomMapper;
     private final ChatMessageMapper chatMessageMapper;
@@ -33,13 +33,23 @@ public class ChatController {
     // /api/chatroom/list/{userId}?page={page}&size={size}
     @GetMapping("/list/{userId}")
     public ResponseEntity<ResponseHandler<PaginationResponseDTO<ChatRoomDTO.ChatRoomList>>> getChatRoomList(@Positive @PathVariable("userId") Long userId,
-                                                                                            @RequestParam int page,
-                                                                                            @RequestParam int size)
+                                                                                                            @RequestParam int page,
+                                                                                                            @RequestParam int size)
     {
-        PaginationResponseDTO<ChatRoomDTO.ChatRoomList> chatRooms  = chatService.getChatRooms(userId, page, size);
+        PaginationResponseDTO<ChatRoomDTO.ChatRoomList> chatRooms  = chatRoomService.getChatRooms(userId, page, size);
 
         return ResponseHandler.response(chatRooms, HttpStatus.OK, "채팅방 목록 조회 성공");
     }
+
+
+    // 단일 채팅방 조회
+    @GetMapping("/{chatroomId}")
+    public ResponseEntity<ResponseHandler<ChatRoomDTO.ChatRoom>> getChatRoomById(@Positive @PathVariable Long chatroomId) {
+        ChatRoomDTO.ChatRoom chatRoom = chatRoomService.getChatRoomById(chatroomId);
+        return ResponseHandler.response(chatRoom, HttpStatus.OK, "채팅방 조회 성공");
+    }
+
+
 
     // 메시지 저장 및 전송
     @MessageMapping("/{chatroomId}/chatmsg")

--- a/src/main/java/sesac_3rd/sesac_3rd/controller/ReportController.java
+++ b/src/main/java/sesac_3rd/sesac_3rd/controller/ReportController.java
@@ -1,0 +1,25 @@
+package sesac_3rd.sesac_3rd.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import sesac_3rd.sesac_3rd.dto.report.ReportDTO;
+import sesac_3rd.sesac_3rd.handler.ResponseHandler;
+import sesac_3rd.sesac_3rd.service.report.ReportService;
+
+
+@RestController
+@RequestMapping("/api/report")
+@RequiredArgsConstructor
+public class ReportController {
+    private final ReportService reportService;
+
+    // 신고 생성
+    @PostMapping
+    public ResponseEntity<ResponseHandler<ReportDTO.Report>> createReport(@RequestBody ReportDTO.Report reportDto) {
+        ReportDTO.Report createdReport = reportService.createReportIfNotExist(reportDto);
+        return ResponseHandler.response(createdReport, HttpStatus.CREATED, "신고 성공");
+    }
+
+}

--- a/src/main/java/sesac_3rd/sesac_3rd/dto/chat/ChatMessageDTO.java
+++ b/src/main/java/sesac_3rd/sesac_3rd/dto/chat/ChatMessageDTO.java
@@ -19,9 +19,9 @@ public class ChatMessageDTO {
     public static class ChatMessageList {
         private Long chatroomId;
         private List<ChatMessageDTO.ChatMessage> chatmsgList;
-        private int page;
-        private int pageSize;
-        private int totalPages;
+//        private int page;
+//        private int pageSize;
+//        private int totalPages;
     }
 
     // 채팅 메세지 단일 (목록, 응답용)

--- a/src/main/java/sesac_3rd/sesac_3rd/dto/chat/ChatRoomDTO.java
+++ b/src/main/java/sesac_3rd/sesac_3rd/dto/chat/ChatRoomDTO.java
@@ -21,9 +21,9 @@ public class ChatRoomDTO {
     public static class ChatRoomList {
         private Long userId;
         private List<ChatRoomDTO.ChatRoom> chatroomList;
-        private int page;
-        private int pageSize;
-        private int totalPages;
+//        private int page;
+//        private int pageSize;
+//        private int totalPages;
     }
 
     // 채팅방 단일

--- a/src/main/java/sesac_3rd/sesac_3rd/dto/report/ReportDTO.java
+++ b/src/main/java/sesac_3rd/sesac_3rd/dto/report/ReportDTO.java
@@ -1,4 +1,37 @@
 package sesac_3rd.sesac_3rd.dto.report;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
 public class ReportDTO {
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Report {
+        private Long reportId;
+        private Long chatMessageId;
+        private Long reviewId;
+        private Long meetingId;
+        private Long reporterId;
+        private Long reportedId;
+        private Long reportReasonId;
+        private String reportReasonName;
+        private String reportMessageContent;
+        private LocalDateTime createdAt;
+    }
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ReportList {
+        private List<Report> reportList;
+    }
 }

--- a/src/main/java/sesac_3rd/sesac_3rd/entity/Report.java
+++ b/src/main/java/sesac_3rd/sesac_3rd/entity/Report.java
@@ -35,6 +35,10 @@ public class Report {
     private User reporter;  // 신고자아이디 (FK)
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "repoted_id", nullable = false)
+    private User reported;  // 피신고자아이디 (FK)
+
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "report_rs_id")
     private ReportReason reportReason;  // 신고사유아이디 (FK)
 

--- a/src/main/java/sesac_3rd/sesac_3rd/exception/ExceptionStatus.java
+++ b/src/main/java/sesac_3rd/sesac_3rd/exception/ExceptionStatus.java
@@ -33,7 +33,14 @@ public enum ExceptionStatus {
     CHATROOM_NOT_FOUND(404, "채팅방을 찾을 수 없습니다."),
     USER_NOT_IN_CHATROOM(404, "채팅방에 소속된 회원이 아닙니다."),
     CHATROOM_NOT_ACTIVE(404, "활성화된 채팅방이 아닙니다."),
-    INVALID_MESSAGE_TYPE(400,"유효한 메세지 타입이 아닙니다.");
+    INVALID_MESSAGE_TYPE(400,"유효한 메세지 타입이 아닙니다."),
+    CHATMSG_NOT_FOUND(404, "채팅 메세지를 찾을 수 없습니다."),
+
+
+    // Report
+    DUPLICATE_REPORT(409, "이미 유효한 신고입니다."),
+    REPORTRS_NOT_FOUND(404, "존재하지 않는 신고유형입니다.");
+
 
     private final int status;
     private final String message;

--- a/src/main/java/sesac_3rd/sesac_3rd/handler/pagination/PageInfo.java
+++ b/src/main/java/sesac_3rd/sesac_3rd/handler/pagination/PageInfo.java
@@ -5,30 +5,37 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.domain.Sort;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Getter
 @NoArgsConstructor
 public class PageInfo {
-    private int page = 1;            // 기본값: 1 (현재 페이지 번호, 1부터 시작)
-    private long totalElements = 0L; // 기본값: 0 (전체 데이터 수)
-    private int totalPages = 1;      // 기본값: 1 (전체 페이지 수)
-    private Sort sort = Sort.unsorted(); // 기본값: 정렬 없음 (UNSORTED)
-
-    /*
-     * 정렬 종류
-     *
-     * 1. Sort.unsorted() - 정렬 없음
-     * 2. Sort.by("fieldName") - 특정 필드 기준 오름차순 정렬
-     * 3. Sort.by(Sort.Order.asc("fieldName")) - 오름차순 정렬
-     * 4. Sort.by(Sort.Order.desc("fieldName")) - 내림차순 정렬
-     * 5. Sort.by("field1", "field2") - 여러 필드 기준 정렬 // "field1"을 기준으로 정렬하고, 값이 같을 경우 "field2"를 기준으로 정렬
-     * 6. Sort.by(Sort.Order.asc("field1"), Sort.Order.desc("field2")) - 복합 정렬
-     */
+    private int page = 1;                 // 기본값: 1  (현재 페이지 번호, 1부터 시작)
+    private int pageSize = 10;            // 기본값: 10 (한 페이지에 보여줄 요소 수)
+    private long totalElements = 0L;      // 기본값: 0  (전체 데이터 수)
+    private int totalPages = 1;           // 기본값: 1  (전체 페이지 수)
+    private List<String> sortFields;      // 정렬 필드 리스트
+    private List<String> sortDirections;  // 정렬 방향 리스트
 
 
-    public PageInfo(int page, long totalElements, int totalPages, Sort sort) {
+    public PageInfo(int page, int pageSize, Long totalElements, int totalPages, Sort sort) {
         this.page = page;
+        this.pageSize = pageSize;
         this.totalElements = totalElements;
         this.totalPages = totalPages;
-        this.sort = sort != null ? sort : Sort.unsorted();
+        this.sortFields = new ArrayList<>();
+        this.sortDirections = new ArrayList<>();
+
+        // sort가 존재하지 않거나 정렬되어있지 않거나 필드나 방향이 없거나 (예외처리)
+        if (sort == null || !sort.isSorted() || sortFields.isEmpty() || sortDirections.isEmpty()) {
+            sort = Sort.by(Sort.Order.asc("id")); // 기본 정렬 설정 (id, asc)
+
+        } else if (sort != null && sort.isSorted()) {
+            for (Sort.Order order : sort) { // 모든 정렬 기준 (정렬 기준이 다수일 때 처리를 위함)
+                this.sortFields.add(order.getProperty());               // 필드
+                this.sortDirections.add(order.getDirection().name());   // 방향
+            }
+        }
     }
 }

--- a/src/main/java/sesac_3rd/sesac_3rd/handler/pagination/PaginationResponseDTO.java
+++ b/src/main/java/sesac_3rd/sesac_3rd/handler/pagination/PaginationResponseDTO.java
@@ -28,6 +28,7 @@ public class PaginationResponseDTO<T> {
     private PageInfo createPageInfo(Page page) {
         return new PageInfo(
                 page.getNumber() + 1,
+                page.getSize(),
                 page.getTotalElements(),
                 page.getTotalPages(),
                 page.getSort());

--- a/src/main/java/sesac_3rd/sesac_3rd/mapper/chat/ChatMessageMapper.java
+++ b/src/main/java/sesac_3rd/sesac_3rd/mapper/chat/ChatMessageMapper.java
@@ -45,7 +45,8 @@ public class ChatMessageMapper {
 
 
     // 채팅방 메세지 목록 조회
-    public static ChatMessageDTO.ChatMessageList ChatMessageListToChatMessageListResponseDTO(Long chatroomId, List<ChatMessage> chatMessages, int page, int pageSize, int totalPages) {
+//    public static ChatMessageDTO.ChatMessageList ChatMessageListToChatMessageListResponseDTO(Long chatroomId, List<ChatMessage> chatMessages, int page, int pageSize, int totalPages) {
+    public static ChatMessageDTO.ChatMessageList ChatMessageListToChatMessageListResponseDTO(Long chatroomId, List<ChatMessage> chatMessages) {
         List<ChatMessageDTO.ChatMessage> chatmsgList = chatMessages.stream()
                 .map(ChatMessageMapper::ChatMessageToChatMessageResponseDTO)
                 .collect(Collectors.toList());
@@ -53,9 +54,9 @@ public class ChatMessageMapper {
         return ChatMessageDTO.ChatMessageList.builder()
                 .chatroomId(chatroomId)
                 .chatmsgList(chatmsgList)
-                .page(page)
-                .pageSize(pageSize)
-                .totalPages(totalPages)
+//                .page(page)
+//                .pageSize(pageSize)
+//                .totalPages(totalPages)
                 .build();
     }
 

--- a/src/main/java/sesac_3rd/sesac_3rd/mapper/chat/ChatRoomMapper.java
+++ b/src/main/java/sesac_3rd/sesac_3rd/mapper/chat/ChatRoomMapper.java
@@ -34,9 +34,6 @@ public class ChatRoomMapper {
     // 채팅방 단일 조회 (소속 유저 포함)
     public static ChatRoomDTO.ChatRoom ChatRoomToChatRoomResponseDTO(ChatRoom chatRoom, List<UserMeeting> userMeetings) {
         List<ChatRoomDTO.UserInfo> userListInChatRoom = userMeetings.stream()
-                // 같은 meetingId 를 가지면서, 수락여부가 true 인 것만 필터링 = 모임 소속 유저
-                .filter(userMeeting -> userMeeting.getMeeting().getMeetingId().equals(chatRoom.getMeeting().getMeetingId())
-                        && Boolean.TRUE.equals(userMeeting.getIsAccepted()))
                 .map(userMeeting -> {
                     User user = userMeeting.getUser();
                     return ChatRoomDTO.UserInfo.builder()
@@ -69,7 +66,7 @@ public class ChatRoomMapper {
 
 
     // 채팅방 목록 조회
-    public static ChatRoomDTO.ChatRoomList ChatRoomListToChatRoomListResponseDTO(Long userId, List<ChatRoom> chatRooms, int page, int pageSize, int totalPages) {
+    public static ChatRoomDTO.ChatRoomList ChatRoomListToChatRoomListResponseDTO(Long userId, List<ChatRoom> chatRooms) {
 
 
 
@@ -94,9 +91,9 @@ public class ChatRoomMapper {
         return ChatRoomDTO.ChatRoomList.builder()
                 .userId(userId)
                 .chatroomList(chatroomList)
-                .page(page)
-                .pageSize(pageSize)
-                .totalPages(totalPages)
+//                .page(page)
+//                .pageSize(pageSize)
+//                .totalPages(totalPages)
                 .build();
     }
 

--- a/src/main/java/sesac_3rd/sesac_3rd/mapper/report/ReportMapper.java
+++ b/src/main/java/sesac_3rd/sesac_3rd/mapper/report/ReportMapper.java
@@ -1,4 +1,52 @@
 package sesac_3rd.sesac_3rd.mapper.report;
 
+import org.springframework.stereotype.Component;
+import sesac_3rd.sesac_3rd.dto.report.ReportDTO;
+import sesac_3rd.sesac_3rd.entity.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
 public class ReportMapper {
+
+    public ReportDTO.Report reportToReportResponseDto(Report report) {
+        return ReportDTO.Report.builder()
+                .reportId(report.getReportId())
+                .chatMessageId(report.getChatMessage() != null ? report.getChatMessage().getSender().getUserId() : null)
+                .reviewId(report.getReview() != null ? report.getReview().getUser().getUserId() : null)
+                .meetingId(report.getMeeting() != null ? report.getMeeting().getMeetingId() : null)
+                .reporterId(report.getReporter().getUserId())
+                .reportedId(report.getReported().getUserId())
+                .reportReasonId(report.getReportReason().getReportRsId())
+                .reportReasonName(report.getReportReason().getReportRsName())
+                .reportMessageContent(report.getReportMessageContent())
+                .createdAt(report.getCreatedAt())
+                .build();
+    }
+
+    public ReportDTO.ReportList reportListToReportListResponseDto(List<Report> reports) {
+        List<ReportDTO.Report> reportList = reports.stream()
+                .map(this::reportToReportResponseDto)
+                .collect(Collectors.toList());
+        return ReportDTO.ReportList.builder()
+                .reportList(reportList)
+                .build();
+    }
+
+    public Report reportDTOtoEntity(ReportDTO.Report reportDto, User reporter, User reported,
+                                 ChatMessage chatMessage, Review review, Meeting meeting, ReportReason reportReason) {
+        Report report = new Report();
+        report.setReporter(reporter);
+        report.setReported(reported);
+        report.setChatMessage(chatMessage);
+        report.setReview(review);
+        report.setMeeting(meeting);
+        report.setReportReason(reportReason);
+        report.setReportMessageContent(reportDto.getReportMessageContent());
+        report.setCreatedAt(LocalDateTime.now());
+        return report;
+    }
+
 }

--- a/src/main/java/sesac_3rd/sesac_3rd/repository/ReportReasonRepository.java
+++ b/src/main/java/sesac_3rd/sesac_3rd/repository/ReportReasonRepository.java
@@ -1,0 +1,9 @@
+package sesac_3rd.sesac_3rd.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import sesac_3rd.sesac_3rd.entity.ReportReason;
+
+import java.util.Optional;
+
+public interface ReportReasonRepository extends JpaRepository<ReportReason, Long> {
+}

--- a/src/main/java/sesac_3rd/sesac_3rd/repository/ReportRepository.java
+++ b/src/main/java/sesac_3rd/sesac_3rd/repository/ReportRepository.java
@@ -1,0 +1,11 @@
+package sesac_3rd.sesac_3rd.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import sesac_3rd.sesac_3rd.entity.*;
+
+@Repository
+public interface ReportRepository extends JpaRepository<Report, Long> {
+    boolean existsByReporterAndChatMessageOrReviewOrMeeting(User reporter, ChatMessage chatMessage, Review review, Meeting meeting);
+
+}

--- a/src/main/java/sesac_3rd/sesac_3rd/repository/UserMeetingRepository.java
+++ b/src/main/java/sesac_3rd/sesac_3rd/repository/UserMeetingRepository.java
@@ -12,4 +12,7 @@ import java.util.Optional;
 
 public interface UserMeetingRepository extends JpaRepository<UserMeeting, Long> {
     boolean existsByUser_UserIdAndMeeting_MeetingId(Long userId, Long meetingId);
+
+    List<UserMeeting> findByMeeting_MeetingId(Long meetingId);
+
 }

--- a/src/main/java/sesac_3rd/sesac_3rd/repository/chat/ChatMessageRepository.java
+++ b/src/main/java/sesac_3rd/sesac_3rd/repository/chat/ChatMessageRepository.java
@@ -1,10 +1,12 @@
 package sesac_3rd.sesac_3rd.repository.chat;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import sesac_3rd.sesac_3rd.entity.ChatMessage;
 
 import java.util.List;
 
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
-    List<ChatMessage> findByChatRoomChatroomId(Long chatRoomId);
+    Page<ChatMessage> findByChatRoomChatroomId(Long chatRoomId, Pageable pageable);
 }

--- a/src/main/java/sesac_3rd/sesac_3rd/service/chat/ChatRoomService.java
+++ b/src/main/java/sesac_3rd/sesac_3rd/service/chat/ChatRoomService.java
@@ -7,12 +7,17 @@ import org.springframework.stereotype.Service;
 import sesac_3rd.sesac_3rd.dto.chat.ChatRoomDTO;
 import sesac_3rd.sesac_3rd.entity.ChatRoom;
 import sesac_3rd.sesac_3rd.entity.Meeting;
+import sesac_3rd.sesac_3rd.entity.UserMeeting;
 import sesac_3rd.sesac_3rd.exception.CustomException;
 import sesac_3rd.sesac_3rd.exception.ExceptionStatus;
 import sesac_3rd.sesac_3rd.handler.pagination.PaginationResponseDTO;
 import sesac_3rd.sesac_3rd.mapper.chat.ChatRoomMapper;
 import sesac_3rd.sesac_3rd.repository.MeetingRepository;
+import sesac_3rd.sesac_3rd.repository.UserMeetingRepository;
 import sesac_3rd.sesac_3rd.repository.chat.ChatRoomRepository;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -20,6 +25,8 @@ public class ChatRoomService {
     private final ChatRoomRepository chatRoomRepository;
     private final ChatRoomMapper chatRoomMapper;
     private final MeetingRepository meetingRepository;
+    private final UserMeetingRepository userMeetingRepository;
+
 
 
 
@@ -30,10 +37,10 @@ public class ChatRoomService {
 
         ChatRoomDTO.ChatRoomList chatRoomList = chatRoomMapper.ChatRoomListToChatRoomListResponseDTO(
                 userId,
-                chatPage.getContent(),
-                chatPage.getNumber() + 1,
-                chatPage.getSize(),
-                chatPage.getTotalPages()
+                chatPage.getContent()
+//                chatPage.getNumber() + 1,
+//                chatPage.getSize(),
+//                chatPage.getTotalPages()
         );
 
         return new PaginationResponseDTO<>(chatRoomList, chatPage);
@@ -56,5 +63,21 @@ public class ChatRoomService {
 
             chatRoomRepository.save(chatRoom);
         }
+    }
+
+
+    // 단일 채팅방 조회
+    public ChatRoomDTO.ChatRoom getChatRoomById(Long chatroomId) {
+        ChatRoom chatRoom = chatRoomRepository.findById(chatroomId)
+                .orElseThrow(() -> new CustomException(ExceptionStatus.CHATROOM_NOT_FOUND));
+
+        List<UserMeeting> userMeetingListByMeetingId = userMeetingRepository.findByMeeting_MeetingId(chatRoom.getMeeting().getMeetingId());
+
+        // 유저미팅 테이블에서 같은 meetingId, accept 상태인 유저 리스트 필터링
+        List<UserMeeting> userListInMeeting = userMeetingListByMeetingId.stream()
+                .filter(userMeeting -> Boolean.TRUE.equals(userMeeting.getIsAccepted()))
+                .collect(Collectors.toList());
+
+        return ChatRoomMapper.ChatRoomToChatRoomResponseDTO(chatRoom, userListInMeeting);
     }
 }

--- a/src/main/java/sesac_3rd/sesac_3rd/service/report/ReportService.java
+++ b/src/main/java/sesac_3rd/sesac_3rd/service/report/ReportService.java
@@ -1,4 +1,65 @@
 package sesac_3rd.sesac_3rd.service.report;
 
-public interface ReportService {
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import sesac_3rd.sesac_3rd.dto.report.ReportDTO;
+import sesac_3rd.sesac_3rd.entity.*;
+import sesac_3rd.sesac_3rd.exception.CustomException;
+import sesac_3rd.sesac_3rd.exception.ExceptionStatus;
+import sesac_3rd.sesac_3rd.mapper.report.ReportMapper;
+import sesac_3rd.sesac_3rd.repository.*;
+import sesac_3rd.sesac_3rd.repository.chat.ChatMessageRepository;
+
+@Service
+@RequiredArgsConstructor
+public class ReportService {
+    private final ReportRepository reportRepository;
+    private final UserRepository userRepository;
+    private final ReportMapper reportMapper;
+    private final ChatMessageRepository chatMessageRepository;
+    private final ReviewRepository reviewRepository;
+    private final MeetingRepository meetingRepository;
+    private final ReportReasonRepository reportReasonRepository;
+
+    @Transactional
+    public ReportDTO.Report createReportIfNotExist(ReportDTO.Report reportDto) {
+        // 각 요소 존재하는지 확인 (신고자, 피신고자, 채팅메세지, 리뷰, 모임, 신고사유)
+        User reporter = userRepository.findById(reportDto.getReporterId())
+                .orElseThrow(() -> new CustomException(ExceptionStatus.USER_NOT_FOUND));
+
+        User reported = userRepository.findById(reportDto.getReportedId())
+                .orElseThrow(() -> new CustomException(ExceptionStatus.USER_NOT_FOUND));
+
+        ChatMessage chatMessage = reportDto.getChatMessageId() != null
+                ? chatMessageRepository.findById(reportDto.getChatMessageId())
+                .orElseThrow(() -> new CustomException(ExceptionStatus.CHATMSG_NOT_FOUND)) : null;
+
+        Review review = reportDto.getReviewId() != null
+                ? reviewRepository.findById(reportDto.getReviewId())
+                .orElseThrow(() -> new CustomException(ExceptionStatus.REVIEWID_NOT_FOUND)) : null;
+
+        Meeting meeting = reportDto.getMeetingId() != null
+                ? meetingRepository.findById(reportDto.getMeetingId())
+                .orElseThrow(() -> new CustomException(ExceptionStatus.MEETING_NOT_FOUND)) : null;
+
+        ReportReason reportReason = reportReasonRepository.findById(reportDto.getReportReasonId())
+                .orElseThrow(() -> new CustomException(ExceptionStatus.REPORTRS_NOT_FOUND));
+
+
+        // 중복 신고 여부 확인
+        boolean isExist = reportRepository.existsByReporterAndChatMessageOrReviewOrMeeting(reporter, chatMessage, review, meeting);
+        if (isExist) {
+            throw new CustomException(ExceptionStatus.DUPLICATE_REPORT);
+        }
+
+
+        // 신고 생성
+        Report report = reportMapper.reportDTOtoEntity(reportDto, reporter, reported, chatMessage, review, meeting, reportReason);
+
+        Report savedReport = reportRepository.save(report);
+
+        return reportMapper.reportToReportResponseDto(savedReport);
+
+    }
 }


### PR DESCRIPTION
1. pagination 에서 sort 부분 수정, 추가 
(PaginationResponseDTO에 pagination 관련 정보들이 모두 들어있어서 각 dto에서는 관련 정보 삭제함)
    - sortFields: 정렬 대상 (기본값 id)
    - sortDirections: 정렬 방법 (기본값 asc)
    - pageSize: 한 페이지 노출 요소 수 (기본값 10)
    => 파라미터로 받으면 됩니다~

2. 채팅 메세지 목록 조회 추가
3. 단일 채팅방 조회 추가

------------------
커밋 추가

1. report 기능 추가
2. fliterChain에 chat, report 추가
3. User reported(피신고자) entity 추가 
(리뷰, 모임, 메세지 ID로 사용자 찾기는 가능하지만,
신고 등록 때마다 블랙리스트 등록 여부를 확인하려니 
다수의 테이블이 너무 자주 조인되는 것 같아서 성능 상 피신고자 엔티티를 추가했습니다.)